### PR TITLE
Feature: Add periodic DNS reresolver 

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - 'v*'
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
 
 name: Build & Release
 

--- a/Readme.md
+++ b/Readme.md
@@ -60,12 +60,12 @@ We are using [bashly](https://github.com/DannyBen/bashly) to compile this.
 
 This project was created like this:
 ```bash
-docker run --rm -it --user $(id -u):$(id -g) --volume "$PWD:/app" dannyben/bashly:1.1.0 init
+docker run --rm -it --user $(id -u):$(id -g) --volume "$PWD:/app" dannyben/bashly:1.1.1 init
 ```
 
 To recompile the project, use this:
 ```bash
-docker run --rm -it --user $(id -u):$(id -g) --volume "$PWD:/app" dannyben/bashly:1.1.0 generate
+docker run --rm -it --user $(id -u):$(id -g) --volume "$PWD:/app" dannyben/bashly:1.1.1 generate
 ```
 
 Static analysis with shellcheck:

--- a/src/lib/wireguard/install_wireguard.sh
+++ b/src/lib/wireguard/install_wireguard.sh
@@ -10,6 +10,7 @@ install_wireguard() {
   check_os_version
   install_wireguard_package
   configure_and_start_wireguard "$wireguard_configuration"
+  configure_and_start_dns_reresolver
 }
 
 check_if_running_in_virtualization() {
@@ -123,4 +124,17 @@ configure_and_start_wireguard() {
     echo -e "You can check if WireGuard is running with: systemctl status wg-quick@flynnt-wg"
     echo -e "If you get something like \"Cannot find device flynnt-wg\", please reboot!"
   fi
+}
+
+configure_and_start_dns_reresolver() {
+  reresolvedns_timer > /etc/systemd/system/wireguard_reresolve-dns.timer
+  reresolvedns_service > /etc/systemd/system/wireguard_reresolve-dns.service
+  mkdir -p /opt/flynnt
+  reresolvedns_script > /opt/flynnt/reresolve-dns.sh
+  chmod +x /opt/flynnt/reresolve-dns.sh
+
+  systemctl daemon-reload
+
+  systemctl start "wireguard_reresolve-dns.timer"
+  systemctl enable "wireguard_reresolve-dns.timer"
 }

--- a/src/lib/wireguard/remove_wireguard.sh
+++ b/src/lib/wireguard/remove_wireguard.sh
@@ -2,12 +2,19 @@
 
 remove_wireguard() {
   systemctl stop "wg-quick@flynnt-wg"
+  systemctl stop "wireguard_reresolve-dns.timer"
+  systemctl stop "wireguard_reresolve-dns.service"
   systemctl disable "wg-quick@flynnt-wg"
+  systemctl disable "wireguard_reresolve-dns.timer"
+  systemctl disable "wireguard_reresolve-dns.service"
 
   rm -f /etc/wireguard/flynnt-wg.conf
   rm -f /etc/sysctl.d/flynnt.conf
+  rm -rf /opt/flynnt
   # Reload sysctl
   sysctl --system
+  # Reload systemd
+  systemctl daemon-reload
   # Check if WireGuard is running
   systemctl is-active --quiet "wg-quick@flynnt-wg"
   WG_RUNNING=$?

--- a/src/lib/wireguard/reresolve_dns.sh
+++ b/src/lib/wireguard/reresolve_dns.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+# This is taken from https://github.com/WireGuard/wireguard-tools/blob/master/contrib/reresolve-dns/reresolve-dns.sh
+reresolvedns_script() {
+  cat <<'EOF'
+#!/bin/bash
+# SPDX-License-Identifier: GPL-2.0
+#
+# Copyright (C) 2015-2020 Jason A. Donenfeld <Jason@zx2c4.com>. All Rights Reserved.
+
+set -e
+shopt -s nocasematch
+shopt -s extglob
+export LC_ALL=C
+
+CONFIG_FILE="$1"
+[[ $CONFIG_FILE =~ ^[a-zA-Z0-9_=+.-]{1,15}$ ]] && CONFIG_FILE="/etc/wireguard/$CONFIG_FILE.conf"
+[[ $CONFIG_FILE =~ /?([a-zA-Z0-9_=+.-]{1,15})\.conf$ ]]
+INTERFACE="${BASH_REMATCH[1]}"
+
+process_peer() {
+	[[ $PEER_SECTION -ne 1 || -z $PUBLIC_KEY || -z $ENDPOINT ]] && return 0
+	[[ $(wg show "$INTERFACE" latest-handshakes) =~ ${PUBLIC_KEY//+/\\+}[[:blank:]]*([0-9]+) ]] || return 0
+	(( ($EPOCHSECONDS - ${BASH_REMATCH[1]}) > 60 )) || return 0
+	wg set "$INTERFACE" peer "$PUBLIC_KEY" endpoint "$ENDPOINT"
+	reset_peer_section
+}
+
+reset_peer_section() {
+	PEER_SECTION=0
+	PUBLIC_KEY=""
+	ENDPOINT=""
+}
+
+reset_peer_section
+while read -r line || [[ -n $line ]]; do
+	stripped="${line%%\#*}"
+	key="${stripped%%=*}"; key="${key##*([[:space:]])}"; key="${key%%*([[:space:]])}"
+	value="${stripped#*=}"; value="${value##*([[:space:]])}"; value="${value%%*([[:space:]])}"
+	[[ $key == "["* ]] && { process_peer; reset_peer_section; }
+	[[ $key == "[Peer]" ]] && PEER_SECTION=1
+	if [[ $PEER_SECTION -eq 1 ]]; then
+		case "$key" in
+		PublicKey) PUBLIC_KEY="$value"; continue ;;
+		Endpoint) ENDPOINT="$value"; continue ;;
+		esac
+	fi
+done < "$CONFIG_FILE"
+process_peer
+EOF
+}
+
+# Services from: https://wiki.archlinux.org/title/WireGuard
+reresolvedns_timer() {
+  cat <<'EOF'
+[Unit]
+Description=Periodically reresolve DNS of Flynnt WireGuard Endpoint
+
+[Timer]
+OnCalendar=*:*:0/30
+
+[Install]
+WantedBy=timers.target
+EOF
+}
+
+reresolvedns_service() {
+  cat <<'EOF'
+[Unit]
+Description=Reresolve DNS of Flynnt WireGuard Endpoint
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c '/opt/flynnt/reresolve-dns.sh /etc/wireguard/flynnt-wg.conf'
+EOF
+}
+


### PR DESCRIPTION
This mitigates connection loss of wireguard when cluster endpoints change.
Wireguard does not re-resolve DNS Name of the peers in wg.conf by itself, so we created a systemd service that does this when handshake is over 60 old